### PR TITLE
Add optional line info output

### DIFF
--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -67,6 +67,7 @@ var (
 	profileFlag               bool
 	quantityIncreasesRiskFlag bool
 	statsFlag                 bool
+	lineInfoFlag              bool
 	thirdPartyFlag            bool
 	verboseFlag               bool
 )
@@ -275,6 +276,7 @@ func main() {
 				Rules:                 yrs,
 				ScanPaths:             scanPaths,
 				Stats:                 statsFlag,
+				LineInfo:              lineInfoFlag,
 			}
 
 			return nil
@@ -380,6 +382,12 @@ func main() {
 				Value:       false,
 				Usage:       "Show scan statistics",
 				Destination: &statsFlag,
+			},
+			&cli.BoolFlag{
+				Name:        "line-info",
+				Value:       false,
+				Usage:       "Include starting line number of YARA matches",
+				Destination: &lineInfoFlag,
 			},
 			&cli.BoolFlag{
 				Name:        "third-party",

--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/chainguard-dev/malcontent/pkg/malcontent"
+	
 
 	"github.com/chainguard-dev/clog"
 	"github.com/chainguard-dev/malcontent/pkg/action"

--- a/pkg/malcontent/malcontent.go
+++ b/pkg/malcontent/malcontent.go
@@ -42,15 +42,19 @@ type Config struct {
 	Scan                  bool
 	ScanPaths             []string
 	Stats                 bool
-	TrimPrefixes          []string
+	// LineInfo enables returning line numbers for matches
+	LineInfo     bool
+	TrimPrefixes []string
 }
 
 type Behavior struct {
 	Description string `json:",omitempty" yaml:",omitempty"`
 	// MatchStrings are all strings found relating to this behavior
 	MatchStrings []string `json:",omitempty" yaml:",omitempty"`
-	RiskScore    int
-	RiskLevel    string `json:",omitempty" yaml:",omitempty"`
+	// MatchLines are the starting lines for each matched string
+	MatchLines []int `json:",omitempty" yaml:",omitempty"`
+	RiskScore  int
+	RiskLevel  string `json:",omitempty" yaml:",omitempty"`
 
 	RuleURL      string `json:",omitempty" yaml:",omitempty"`
 	ReferenceURL string `json:",omitempty" yaml:",omitempty"`

--- a/pkg/report/lines_test.go
+++ b/pkg/report/lines_test.go
@@ -1,0 +1,56 @@
+package report
+
+import (
+	"context"
+	"testing"
+
+	yarax "github.com/VirusTotal/yara-x/go"
+	"github.com/chainguard-dev/malcontent/pkg/malcontent"
+)
+
+func TestMatchStringsWithLines(t *testing.T) {
+	strings := []string{"abc", "abc", "abcd"}
+	lines := []int{1, 2, 3}
+
+	gotStr, gotLines := matchStringsWithLines("rule", strings, lines)
+
+	wantStr := []string{"abcd", "abc"}
+	wantLines := []int{3, 1}
+
+	if len(gotStr) != len(wantStr) {
+		t.Fatalf("strings length got %d want %d", len(gotStr), len(wantStr))
+	}
+	for i := range wantStr {
+		if gotStr[i] != wantStr[i] || gotLines[i] != wantLines[i] {
+			t.Errorf("index %d got (%s,%d) want (%s,%d)", i, gotStr[i], gotLines[i], wantStr[i], wantLines[i])
+		}
+	}
+}
+
+func TestGenerateLineInfo(t *testing.T) {
+	rule := `rule test { strings: $a = "bar" condition: $a }`
+	comp := yarax.NewCompiler()
+	if err := comp.AddString(rule, ""); err != nil {
+		t.Fatalf("compile rule: %v", err)
+	}
+	yrs, err := comp.GetRules()
+	if err != nil {
+		t.Fatalf("get rules: %v", err)
+	}
+	scanner := yarax.NewScanner(yrs)
+	fc := []byte("foo\nbar\nbaz\n")
+	mrs, err := scanner.Scan(fc)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	fr, err := Generate(context.Background(), "testfile", mrs, malcontent.Config{LineInfo: true}, "", nil, fc, nil)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if len(fr.Behaviors) == 0 || len(fr.Behaviors[0].MatchLines) == 0 {
+		t.Fatalf("expected match lines")
+	}
+	if fr.Behaviors[0].MatchLines[0] != 2 {
+		t.Errorf("line = %d, want 2", fr.Behaviors[0].MatchLines[0])
+	}
+}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -317,6 +317,38 @@ func matchStrings(ruleName string, ms []string) []string {
 	return longestUnique(raw)
 }
 
+func matchStringsWithLines(ruleName string, ms []string, lines []int) ([]string, []int) {
+	if len(ms) == 0 {
+		return nil, nil
+	}
+
+	safe := make([]string, len(ms))
+	copy(safe, ms)
+	safeLines := make([]int, len(lines))
+	copy(safeLines, lines)
+
+	raw := make([]string, 0, len(safe))
+	lineMap := make(map[string]int, len(safe))
+
+	for i, m := range safe {
+		str := matchToString(ruleName, m)
+		if str != "" {
+			raw = append(raw, str)
+			if l, ok := lineMap[str]; !ok || safeLines[i] < l {
+				lineMap[str] = safeLines[i]
+			}
+		}
+	}
+
+	unique := longestUnique(raw)
+	outLines := make([]int, len(unique))
+	for i, s := range unique {
+		outLines[i] = lineMap[s]
+	}
+
+	return unique, outLines
+}
+
 // sizeAndChecksum calculates size and checksum using already-read file contents if available.
 func sizeAndChecksum(fc []byte) (int64, string) {
 	var checksum string
@@ -478,12 +510,20 @@ func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcon
 			}
 
 			processor := newMatchProcessor(fc, matches, m.Patterns())
-			matchedStrings = processor.process()
+			var matchedLines []int
+			matchedStrings, matchedLines = processor.process(c.LineInfo)
+		}
+
+		var matchLines []int
+		matchStringsProcessed := matchStrings(m.Identifier(), matchedStrings)
+		if c.LineInfo {
+			matchStringsProcessed, matchLines = matchStringsWithLines(m.Identifier(), matchedStrings, matchedLines)
 		}
 
 		b := &malcontent.Behavior{
 			ID:           key,
-			MatchStrings: matchStrings(m.Identifier(), matchedStrings),
+			MatchStrings: matchStringsProcessed,
+			MatchLines:   matchLines,
 			RiskLevel:    RiskLevels[risk],
 			RiskScore:    risk,
 			RuleName:     m.Identifier(),

--- a/pkg/report/strings.go
+++ b/pkg/report/strings.go
@@ -70,17 +70,25 @@ var matchResultPool = sync.Pool{
 	},
 }
 
+var lineResultPool = sync.Pool{
+	New: func() any {
+		s := make([]int, 0, 32)
+		return &s
+	},
+}
+
 // process performantly handles the conversion of matched data to strings.
 // yara-x does not expose the rendered string via the API due to performance overhead.
-func (mp *matchProcessor) process() []string {
+func (mp *matchProcessor) process(lineInfo bool) ([]string, []int) {
 	if len(mp.matches) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	mp.mu.Lock()
 	defer mp.mu.Unlock()
 
 	var result *[]string
+	var lineResult *[]int
 	var ok bool
 	if result, ok = matchResultPool.Get().(*[]string); ok {
 		*result = (*result)[:0]
@@ -89,6 +97,17 @@ func (mp *matchProcessor) process() []string {
 		result = &slice
 	}
 	defer matchResultPool.Put(result)
+
+	if lineInfo {
+		if lr, ok := lineResultPool.Get().(*[]int); ok {
+			*lr = (*lr)[:0]
+			lineResult = lr
+		} else {
+			slice := make([]int, 0, 32)
+			lineResult = &slice
+		}
+		defer lineResultPool.Put(lineResult)
+	}
 
 	initializeOnce.Do(func() {
 		matchPool = pool.NewBufferPool(len(mp.matches))
@@ -110,6 +129,10 @@ func (mp *matchProcessor) process() []string {
 		}
 
 		matchBytes := mp.fc[o : o+l]
+		if lineInfo {
+			line := 1 + bytes.Count(mp.fc[:o], []byte{'\n'})
+			*lineResult = append(*lineResult, line)
+		}
 
 		if !containsUnprintable(matchBytes) {
 			if l <= cap(buffer) {
@@ -134,8 +157,13 @@ func (mp *matchProcessor) process() []string {
 
 	finalResult := make([]string, len(*result))
 	copy(finalResult, *result)
+	var finalLines []int
+	if lineInfo {
+		finalLines = make([]int, len(*lineResult))
+		copy(finalLines, *lineResult)
+	}
 
-	return finalResult
+	return finalResult, finalLines
 }
 
 // containsUnprintable determines if a byte is a valid character.


### PR DESCRIPTION
## Summary
- add `LineInfo` option to config and CLI `--line-info`
- return line numbers from rule matches when enabled
- extend json output with new `MatchLines` field
- unit tests for line number processing

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.0)*